### PR TITLE
Bugfix: ASCII encoding of author list

### DIFF
--- a/backend/lib/ResultGraph.py
+++ b/backend/lib/ResultGraph.py
@@ -162,8 +162,8 @@ class ResultGraph():
         author_lst = [author for author in author_lst if author!='']
         author_counts = Counter(author_lst)
         top_authors = author_counts.most_common(5)
-        top_authors_list = ['{0} ({1})'.format(str(author[0]), str(author[1])) for author in top_authors]
-        top_authors = ', '.join(['{0} ({1})'.format(author[0], author[1]) for author in top_authors])
+        top_authors_list = ['{0} ({1})'.format(author[0].encode('utf-8'), str(author[1])) for author in top_authors]
+        top_authors = ', '.join(['{0} ({1})'.format(author[0].encode('utf-8'), str(author[1])) for author in top_authors])
 
         # Get list of publication years
         pub_years = []

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -38,7 +38,7 @@ def getGraph(*args, **kwargs):
         graphJSON = json.loads(graphSession.get_cy_json(graph_format=kwargs['graph_format'], mode=kwargs['mode']))
         log.info('Logging in getGraph of worker')
         return graphJSON
-    except Exception:
-        log.error(traceback.print_exc())
-        traceback.print_exc()
+    except Exception as e:
+        traceback_str = traceback.format_exc()
+        log.error(traceback_str)
         return graphSession.return_empty_graph()


### PR DESCRIPTION
Linked to issue #29 ("Fix ASCII bug")
Necessary changes:
* In Celery, instead of breaking task management, except errors in API and return empty graph.
* Use UTF-8 encoding for top authors in ResultGraph.py